### PR TITLE
Ignore specifically the rprel executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 erl_crash.dump
 *.ez
 *.beam
-rprel
+/rprel


### PR DESCRIPTION
Previous ignore expression was also matching ./lib/rprel etc, not just the top level rprel executable