### PR TITLE
Use import for specs

### DIFF
--- a/test/rprel/build_test.exs
+++ b/test/rprel/build_test.exs
@@ -1,6 +1,7 @@
 defmodule Rprel.BuildTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureIO
+  import Rprel.Build
 
   setup_all do
     build_path = Path.relative_to_cwd("test/rprel/test_build")
@@ -23,7 +24,7 @@ defmodule Rprel.BuildTest do
 
   test "it creates a build-info file", context do
     capture_io(fn ->
-      Rprel.Build.create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]])
+      create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]])
     end)
 
     assert File.exists?(Path.join(context[:build_path], "BUILD-INFO")) == true
@@ -31,7 +32,7 @@ defmodule Rprel.BuildTest do
 
   test "it writes the correct build info template", context do
     capture_io(fn ->
-      Rprel.Build.create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]])
+      create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]])
     end)
 
     assert File.read(Path.join(context[:build_path], "BUILD-INFO")) == {:ok,
@@ -45,7 +46,7 @@ defmodule Rprel.BuildTest do
 
   test "it archives the directory", context do
     message = capture_io(fn ->
-      Rprel.Build.create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]])
+      create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]])
     end)
 
     assert String.contains?(message,"created #{context[:date]}-#{context[:build_number]}-#{context[:short_sha]}.tgz\n")
@@ -54,7 +55,7 @@ defmodule Rprel.BuildTest do
 
   test "it runs the archive by default", context do
     message = capture_io(fn ->
-      Rprel.Build.create([path: context[:build_archive_path], build_number: context[:build_number], commit: context[:sha]])
+      create([path: context[:build_archive_path], build_number: context[:build_number], commit: context[:sha]])
     end)
 
     assert String.contains?(message, "running archive")
@@ -62,7 +63,7 @@ defmodule Rprel.BuildTest do
 
   test "it stops and prints an error when archive fails", context do
     message = capture_io(fn ->
-      Rprel.Build.create([path: context[:fail_archive_path], build_number: context[:build_number], commit: context[:sha]])
+      create([path: context[:fail_archive_path], build_number: context[:build_number], commit: context[:sha]])
     end)
 
     refute File.exists?(Path.join(context[:fail_archive_path], 'archive.tgz'))
@@ -70,13 +71,13 @@ defmodule Rprel.BuildTest do
   end
 
   test "it returns an error with an invalid build path", context do
-    build = Rprel.Build.create([path: 'missing-directory', build_number: context[:build_number], commit: context[:sha]])
+    build = create([path: 'missing-directory', build_number: context[:build_number], commit: context[:sha]])
     assert {:error, "You must supply a valid path"} = build
   end
 
   test "it runs the build by default", context do
     error_message = capture_io(fn ->
-      assert Rprel.Build.create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]]) == {:ok, nil}
+      assert create([path: context[:build_path], build_number: context[:build_number], commit: context[:sha]]) == {:ok, nil}
     end)
 
     refute String.contains?(error_message, "build not found, skipping build step")
@@ -84,14 +85,14 @@ defmodule Rprel.BuildTest do
 
   test "it returns an error if the build does not work", context do
     error_message = capture_io(fn ->
-      Rprel.Build.create([path: context[:fail_to_build_path], build_number: context[:build_number], commit: context[:sha]])
+      create([path: context[:fail_to_build_path], build_number: context[:build_number], commit: context[:sha]])
     end)
     assert String.contains?(error_message, "build returned an error")
   end
 
   test "it returns a warning if the build is missing", context do
     error_message = capture_io(fn ->
-      Rprel.Build.create([path: context[:missing_buildsh_path], build_number: context[:build_number], commit: context[:sha]])
+      create([path: context[:missing_buildsh_path], build_number: context[:build_number], commit: context[:sha]])
     end)
 
     assert String.contains?(error_message, "build not found, skipping build step")

--- a/test/rprel/cli_test.exs
+++ b/test/rprel/cli_test.exs
@@ -2,6 +2,7 @@ defmodule Rprel.CLITest do
   use ExUnit.Case, async: true
 
   alias Rprel.Messages
+  import Rprel.CLI
 
   @ok_resp {:ok, ""}
 
@@ -12,85 +13,85 @@ defmodule Rprel.CLITest do
   @release_cmd ["release", "--repo", @repo, "--token", @token, "--commit", @commit, "--version", @version, __ENV__.file]
 
   test "it returns help text if called with no args" do
-    assert Rprel.CLI.do_main([]) == {:ok, Messages.help_text}
+    assert do_main([]) == {:ok, Messages.help_text}
   end
 
   test "it returns the help text if called with either --help or -h" do
-    assert Rprel.CLI.do_main(["--help"]) == {:ok, Messages.help_text}
-    assert Rprel.CLI.do_main(["-h"]) == {:ok, Messages.help_text}
+    assert do_main(["--help"]) == {:ok, Messages.help_text}
+    assert do_main(["-h"]) == {:ok, Messages.help_text}
   end
 
   test "it returns the version if called with either --version or -v" do
-    assert Rprel.CLI.do_main(["-v"]) == {:ok, Rprel.version}
-    assert Rprel.CLI.do_main(["--version"]) == {:ok, Rprel.version}
+    assert do_main(["-v"]) == {:ok, Rprel.version}
+    assert do_main(["--version"]) == {:ok, Rprel.version}
   end
 
   test "it shows help for the build command" do
-    assert Rprel.CLI.do_main(["help", "build"]) == {:ok, Messages.build_help_text}
-    assert Rprel.CLI.do_main(["build", "--help"]) == {:ok, Messages.build_help_text}
-    assert Rprel.CLI.do_main(["build", "-h"]) == {:ok, Messages.build_help_text}
+    assert do_main(["help", "build"]) == {:ok, Messages.build_help_text}
+    assert do_main(["build", "--help"]) == {:ok, Messages.build_help_text}
+    assert do_main(["build", "-h"]) == {:ok, Messages.build_help_text}
   end
 
   test "it shows help for the release command" do
-    assert Rprel.CLI.do_main(["help", "release"]) == {:ok, Messages.release_help_text}
-    assert Rprel.CLI.do_main(["release", "--help"]) == {:ok, Messages.release_help_text}
-    assert Rprel.CLI.do_main(["release", "-h"]) == {:ok, Messages.release_help_text}
+    assert do_main(["help", "release"]) == {:ok, Messages.release_help_text}
+    assert do_main(["release", "--help"]) == {:ok, Messages.release_help_text}
+    assert do_main(["release", "-h"]) == {:ok, Messages.release_help_text}
   end
 
   test "a release is created when given the required args" do
-    result = Rprel.CLI.do_main(@release_cmd)
+    result = do_main(@release_cmd)
     assert result == @ok_resp
   end
 
   test "a repo name is required when releasing" do
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--repo") |> List.delete(@repo))
+    result = do_main(@release_cmd |> List.delete("--repo") |> List.delete(@repo))
     assert result == {:error, Messages.invalid_repo_name_msg}
   end
 
   test "a version name is required when releasing" do
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--version") |> List.delete(@version))
+    result = do_main(@release_cmd |> List.delete("--version") |> List.delete(@version))
     assert result == {:error, Messages.invalid_version_msg}
   end
 
   test "a commit name is required when releasing" do
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--commit") |> List.delete(@commit))
+    result = do_main(@release_cmd |> List.delete("--commit") |> List.delete(@commit))
     assert result == {:error, Messages.invalid_commit_msg}
   end
 
   test "an auth token is required when releasing" do
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--token") |> List.delete(@token))
+    result = do_main(@release_cmd |> List.delete("--token") |> List.delete(@token))
     assert result == {:error, Messages.invalid_token_msg}
   end
 
   test "at least one file is required when releasing" do
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete(__ENV__.file))
+    result = do_main(@release_cmd |> List.delete(__ENV__.file))
     assert result == {:error, Messages.invalid_files_msg}
   end
 
   test "the repo can be specified through an env var" do
     System.put_env("RELEASE_REPO", @repo)
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--repo") |> List.delete(@repo))
+    result = do_main(@release_cmd |> List.delete("--repo") |> List.delete(@repo))
     assert result == @ok_resp
     System.delete_env("RELEASE_REPO")
   end
 
   test "the version can be specified through an env var" do
     System.put_env("RELEASE_VERSION", @version)
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--version") |> List.delete(@version))
+    result = do_main(@release_cmd |> List.delete("--version") |> List.delete(@version))
     assert result == @ok_resp
     System.delete_env("RELEASE_VERSION")
   end
 
   test "the commit can be specified through an env var" do
     System.put_env("RELEASE_COMMIT", @commit)
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--commit") |> List.delete(@commit))
+    result = do_main(@release_cmd |> List.delete("--commit") |> List.delete(@commit))
     assert result == @ok_resp
     System.delete_env("RELEASE_COMMIT")
   end
 
   test "the auth token can be specified through an env var" do
     System.put_env("GITHUB_AUTH_TOKEN", @token)
-    result = Rprel.CLI.do_main(@release_cmd |> List.delete("--token") |> List.delete(@token))
+    result = do_main(@release_cmd |> List.delete("--token") |> List.delete(@token))
     assert result == @ok_resp
     System.delete_env("GITHUB_AUTH_TOKEN")
   end

--- a/test/rprel/release_creator_test.exs
+++ b/test/rprel/release_creator_test.exs
@@ -1,5 +1,6 @@
 defmodule Rprel.ReleaseCreatorTest do
   use ExUnit.Case, async: true
+  import Rprel.ReleaseCreator
 
   @files [__ENV__.file, __ENV__.file]
   @token  [token: "token"]
@@ -11,47 +12,47 @@ defmodule Rprel.ReleaseCreatorTest do
 
   test "it creates a GitHub release" do
     release = %Rprel.GithubRelease{name: @name, version: @version, commit: @commit}
-    created_release = Rprel.ReleaseCreator.create(release, @files, @token)
+    created_release = create(release, @files, @token)
     assert {:ok, [id: _]} = created_release
   end
 
   test "a repo name is required" do
-    resp = Rprel.ReleaseCreator.create(struct(@release, name: nil), @files, @token)
+    resp = create(struct(@release, name: nil), @files, @token)
     assert resp == {:error, :invalid_repo_name}
   end
 
   test "the repo name must have a owner and repo" do
-    resp = Rprel.ReleaseCreator.create(struct(@release, name: "test-bed"), @files, @token)
+    resp = create(struct(@release, name: "test-bed"), @files, @token)
     assert resp == {:error, :invalid_repo_name}
   end
 
   test "a version is required" do
-    resp = Rprel.ReleaseCreator.create(struct(@release, version: nil), @files, @token)
+    resp = create(struct(@release, version: nil), @files, @token)
     assert resp == {:error, :missing_version}
   end
 
   test "a commit sha is required" do
-    resp = Rprel.ReleaseCreator.create(struct(@release, commit: nil), @files, @token)
+    resp = create(struct(@release, commit: nil), @files, @token)
     assert resp == {:error, :missing_commit}
   end
 
   test "at least one file must be provided" do
-    resp = Rprel.ReleaseCreator.create(@release, nil, @token)
+    resp = create(@release, nil, @token)
     assert resp == {:error, :missing_files}
   end
 
   test "the provided files must be readable" do
-    resp = Rprel.ReleaseCreator.create(@release, ["filethatdoesnotexist.txt"], @token)
+    resp = create(@release, ["filethatdoesnotexist.txt"], @token)
     assert resp == {:error, :unreadable_files}
   end
 
   test "an auth token must be provided" do
-    resp = Rprel.ReleaseCreator.create(@release, @files, nil)
+    resp = create(@release, @files, nil)
     assert resp == {:error, :invalid_auth_token}
   end
 
   test "the auth token cannot be an empty binary" do
-    resp = Rprel.ReleaseCreator.create(@release, @files, token: "")
+    resp = create(@release, @files, token: "")
     assert resp == {:error, :invalid_auth_token}
   end
 end


### PR DESCRIPTION
- Import modules for specs, to eliminate namespacing
of module functions.

@rawsyntax & @colinrymer  Thoughts? I don't know if this is more clear or not... 