### PR TITLE
[MPN] Add Branch Argument

### DIFF
--- a/lib/rprel/cli.ex
+++ b/lib/rprel/cli.ex
@@ -13,8 +13,8 @@ defmodule Rprel.CLI do
   @build_flags [help: :boolean, build_number: :string, commit: :string, path: :string]
   @build_aliases [h: :help]
 
-  @release_flags [help: :boolean, token: :string, commit: :string, repo: :string, version: :string]
-  @release_aliases [h: :help, t: :token, c: :commit, r: :repo, v: :version]
+  @release_flags [help: :boolean, token: :string, commit: :string, repo: :string, version: :string, branch: :string]
+  @release_aliases [h: :help, t: :token, c: :commit, r: :repo, v: :version, b: :branch]
 
   @system Application.get_env(:rprel, :system)
 
@@ -91,6 +91,7 @@ defmodule Rprel.CLI do
     opts
     |> Keyword.put_new(:token, System.get_env("GITHUB_AUTH_TOKEN"))
     |> Keyword.put_new(:commit, System.get_env("RELEASE_COMMIT"))
+    |> Keyword.put_new(:branch, System.get_env("RELEASE_BRANCH"))
     |> Keyword.put_new(:repo, System.get_env("RELEASE_REPO"))
     |> Keyword.put_new(:version, System.get_env("RELEASE_VERSION"))
   end

--- a/lib/rprel/github_release.ex
+++ b/lib/rprel/github_release.ex
@@ -8,5 +8,5 @@ defmodule Rprel.GithubRelease do
                            creds :: [token: String.t]) :: {:ok, id :: String.t} | {:error, msg :: String.t}
   @callback valid_token?(token :: String.t) :: boolean
 
-  defstruct [:name, :version, :commit, :id, :upload_url]
+  defstruct [:name, :version, :commit, :id, :upload_url, :branch]
 end

--- a/lib/rprel/github_release/http.ex
+++ b/lib/rprel/github_release/http.ex
@@ -67,6 +67,6 @@ defmodule Rprel.GithubRelease.HTTP do
 
   defp formatted_release_body(release) do
     Poison.encode!(%{tag_name: release.version, name: release.version,
-                     commitish: release.commit, prerelease: true})
+                     commitish: release.commit, prerelease: true, body: "branch: #{release.branch}"})
   end
 end

--- a/lib/rprel/messages.ex
+++ b/lib/rprel/messages.ex
@@ -5,6 +5,7 @@ defmodule Rprel.Messages do
 
   def invalid_repo_name, do: "You must provide a full repo name."
   def invalid_commit, do: "You must provide a commit sha."
+  def invalid_branch, do: "You must provide a branch."
   def invalid_version, do: "You must provide a version number."
   def invalid_files, do: "You must provide at least one valid file."
   def invalid_auth_token, do: "You must provide a valid GitHub authentication token."
@@ -73,6 +74,8 @@ defmodule Rprel.Messages do
            The full repo name, OWNER/REPO, where the release will be created [$RELEASE_REPO]
        --version VERSION, -v VERSION
            The release VERSION [$RELEASE_VERSION]
+       --branch BRANCH, -b BRANCH
+           The branch that the SHA is tied to [$RELEASE_BRANCH]
     """
   end
 end

--- a/lib/rprel/release_creator.ex
+++ b/lib/rprel/release_creator.ex
@@ -7,7 +7,7 @@ defmodule Rprel.ReleaseCreator do
   @github_api Application.get_env(:rprel, :github_api)
 
   def create(opts, files) do
-    release_info = %Rprel.GithubRelease{name: opts[:repo], version: opts[:version], commit: opts[:commit]}
+    release_info = %Rprel.GithubRelease{name: opts[:repo], version: opts[:version], commit: opts[:commit], branch: opts[:branch]}
     case create(release_info, files, [token: opts[:token]]) do
       {:error, error_atom} ->
         {:error, apply(Messages, error_atom, [])}
@@ -27,6 +27,7 @@ defmodule Rprel.ReleaseCreator do
     with :ok <- validate_repo_name(release.name),
          :ok <- validate_version(release.version),
          :ok <- validate_commit(release.commit),
+         :ok <- validate_branch(release.branch),
          do: :ok
   end
 
@@ -56,6 +57,10 @@ defmodule Rprel.ReleaseCreator do
 
   defp validate_commit(commit) do
     if commit, do: :ok, else: {:error, :invalid_commit}
+  end
+
+  defp validate_branch(branch) do
+    if branch, do: :ok, else: {:error, :invalid_branch}
   end
 
   defp readable?(files) when is_list(files) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule Rprel.Mixfile do
 
   def project do
     [app: :rprel,
-     version: "1.1.6",
-     elixir: "~> 1.2",
+     version: "2.0.0",
+     elixir: "~> 1.3.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      escript: [main_module: Rprel.CLI],

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "bypass": {:hex, :bypass, "0.5.1", "cf3e8a4d376ee1dcd89bf362dfaf1f4bf4a6e19895f52fdc2bafbd8207ce435f", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
-  "combine": {:hex, :combine, "0.8.0", "390fe5f632a8c890d378abc697ca7c4c52cd3e38bb232a5cad1677cd4af013df", [:mix], []},
+  "combine": {:hex, :combine, "0.9.3", "192e609b48b3f2210494e26f85db1712657be1a8f15795656710317ea43fc449", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.4.5", "5c5daaf50a2a96068c0f21b6fbd382d206702efa8836a946eeab0b8ac25f5f22", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},

--- a/test/rprel/cli_test.exs
+++ b/test/rprel/cli_test.exs
@@ -11,7 +11,8 @@ defmodule Rprel.CLITest do
   @repo "rentpath/test-bed"
   @token "iamatoken"
   @version "v1.1.2"
-  @release_cmd ["release", "--repo", @repo, "--token", @token, "--commit", @commit, "--version", @version, __ENV__.file]
+  @branch "fml/123/fake_branch"
+  @release_cmd ["release", "--repo", @repo, "--token", @token, "--commit", @commit, "--branch", @branch, "--version", @version, __ENV__.file]
 
   test "it returns help text if called with no args" do
     message =
@@ -87,7 +88,10 @@ defmodule Rprel.CLITest do
   test "a repo name is required when releasing" do
     result =
       capture_io(fn ->
-        main(@release_cmd |> List.delete("--repo") |> List.delete(@repo))
+        @release_cmd
+        |> List.delete("--repo")
+        |> List.delete(@repo)
+        |> main
       end)
       |> String.trim
 
@@ -97,19 +101,36 @@ defmodule Rprel.CLITest do
   test "a version name is required when releasing" do
     result =
       capture_io(fn ->
-        main(@release_cmd
-                |> List.delete("--version")
-                |> List.delete(@version))
+        @release_cmd
+        |> List.delete("--version")
+        |> List.delete(@version)
+        |> main
       end)
       |> String.trim
 
     assert result == Messages.invalid_version
   end
 
+  test "a branch name is required when releasing" do
+    result =
+      capture_io(fn ->
+        @release_cmd
+        |> List.delete("--branch")
+        |> List.delete(@branch)
+        |> main
+      end)
+      |> String.trim
+
+    assert result == Messages.invalid_branch
+  end
+
   test "a commit name is required when releasing" do
     result =
       capture_io(fn ->
-        main(@release_cmd |> List.delete("--commit") |> List.delete(@commit))
+        @release_cmd
+        |> List.delete("--commit")
+        |> List.delete(@commit)
+        |> main
       end)
       |> String.trim
 
@@ -119,7 +140,10 @@ defmodule Rprel.CLITest do
   test "an auth token is required when releasing" do
     result =
       capture_io(fn ->
-        main(@release_cmd |> List.delete("--token") |> List.delete(@token))
+        @release_cmd
+        |> List.delete("--token")
+        |> List.delete(@token)
+        |> main
       end)
       |> String.trim
 
@@ -129,7 +153,9 @@ defmodule Rprel.CLITest do
   test "at least one file is required when releasing" do
     result =
       capture_io(fn ->
-        main(@release_cmd |> List.delete(__ENV__.file))
+        @release_cmd
+        |> List.delete(__ENV__.file)
+        |> main
       end)
       |> String.trim
 
@@ -138,28 +164,55 @@ defmodule Rprel.CLITest do
 
   test "the repo can be specified through an env var" do
     System.put_env("RELEASE_REPO", @repo)
-    result = main(@release_cmd |> List.delete("--repo") |> List.delete(@repo))
+    result =
+      @release_cmd
+      |> List.delete("--repo")
+      |> List.delete(@repo)
+      |> main
     assert result == @ok_resp
     System.delete_env("RELEASE_REPO")
   end
 
   test "the version can be specified through an env var" do
     System.put_env("RELEASE_VERSION", @version)
-    result = main(@release_cmd |> List.delete("--version") |> List.delete(@version))
+    result =
+      @release_cmd
+      |> List.delete("--version")
+      |> List.delete(@version)
+      |> main
     assert result == @ok_resp
     System.delete_env("RELEASE_VERSION")
   end
 
   test "the commit can be specified through an env var" do
     System.put_env("RELEASE_COMMIT", @commit)
-    result = main(@release_cmd |> List.delete("--commit") |> List.delete(@commit))
+    result =
+      @release_cmd
+      |> List.delete("--commit")
+      |> List.delete(@commit)
+      |> main
     assert result == @ok_resp
     System.delete_env("RELEASE_COMMIT")
   end
 
+  test "the branch can be specified through an env var" do
+    System.put_env("RELEASE_BRANCH", @branch)
+    result =
+      @release_cmd
+      |> List.delete("--branch")
+      |> List.delete(@branch)
+      |> main
+    assert result == @ok_resp
+    System.delete_env("RELEASE_BRANCH")
+  end
+
   test "the auth token can be specified through an env var" do
     System.put_env("GITHUB_AUTH_TOKEN", @token)
-    result = main(@release_cmd |> List.delete("--token") |> List.delete(@token))
+    result =
+      @release_cmd
+      |> List.delete("--token")
+      |> List.delete(@token)
+      |> main
     assert result == @ok_resp
     System.delete_env("GITHUB_AUTH_TOKEN")
   end

--- a/test/rprel/github_api/http_test.exs
+++ b/test/rprel/github_api/http_test.exs
@@ -6,7 +6,8 @@ defmodule Rprel.GithubRelease.HTTPTest do
   @full_repo_name "rentpath/test-bed"
   @release_id 1234
   @version "v1.1.2"
-  @normal_release %Rprel.GithubRelease{name: @full_repo_name, version: @version, commit: @commit}
+  @branch "fml/123/fake_branch"
+  @normal_release %Rprel.GithubRelease{name: @full_repo_name, version: @version, commit: @commit, branch: @branch}
 
   def release_upload_url do
     "#{Application.get_env(:rprel, :github_upload_endpoint)}/repos/#{@full_repo_name}/releases/#{@release_id}/assets{?name,label}"
@@ -57,6 +58,7 @@ defmodule Rprel.GithubRelease.HTTPTest do
       assert body_data["name"] == @version
       assert body_data["commitish"]  == @commit
       assert body_data["prerelease"] == true
+      assert body_data["body"] == "branch: #{@branch}"
       Plug.Conn.resp(conn, 201, release_created_json_resp)
     end)
 

--- a/test/rprel/release_creator_test.exs
+++ b/test/rprel/release_creator_test.exs
@@ -7,11 +7,12 @@ defmodule Rprel.ReleaseCreatorTest do
   @name "rentpath/test-bed"
   @version "v1.1.2"
   @commit "1a2b3c4"
+  @branch "fml/123/fake_branch"
 
-  @release %Rprel.GithubRelease{name: @name, version: @version, commit: @commit}
+  @release %Rprel.GithubRelease{name: @name, version: @version, commit: @commit, branch: @branch}
 
   test "it creates a GitHub release" do
-    release = %Rprel.GithubRelease{name: @name, version: @version, commit: @commit}
+    release = %Rprel.GithubRelease{name: @name, version: @version, commit: @commit, branch: @branch}
     created_release = create(release, @files, @token)
     assert {:ok, [id: _]} = created_release
   end


### PR DESCRIPTION
It has started to seem like it would be better if we passed the branch of the build in. We seem to want to know it everywhere. So I added it as an argument to the rprel inputs. Anywhere that calls rprel would need to be updated to add this argument to the rprel call.

But it means moving forward there is a direct connection between the build and what branch it was created from.