### PR TITLE
[MPN] Bump timeout on file uploads

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,6 @@ use Mix.Config
 config :rprel, github_api_endpoint: "https://api.github.com"
 config :porcelain, driver: Porcelain.Driver.Basic
 config :rprel, system: System
+config :rprel, file_upload_timeout: 100_000
 
 import_config "#{Mix.env}.exs"
-

--- a/lib/rprel/github_release/http.ex
+++ b/lib/rprel/github_release/http.ex
@@ -6,6 +6,8 @@ defmodule Rprel.GithubRelease.HTTP do
 
   @behaviour Rprel.GithubRelease
 
+  @timeout Application.get_env(:rprel, :file_upload_timeout)
+
   @spec create_release(release :: %Rprel.GithubRelease{}, files :: list | String.t, creds :: [token: String.t]) :: {:ok, id :: String.t} | {:error, msg :: String.t}
   def create_release(release = %Rprel.GithubRelease{}, files, [token: token]) do
     with {:ok, [id: id, upload_url: upload_url]} <-
@@ -57,9 +59,8 @@ defmodule Rprel.GithubRelease.HTTP do
   defp auth_header(token), do: %{"Authorization" => "token #{token}"}
 
   defp authenticated_post(url, body, token) do
-    timeout = Application.get_env(:rprel, :file_upload_timeout)
     HTTPoison.post!(url, body, auth_header(token),
-      [connect_timeout: timeout, recv_timeout: timeout, timeout: timeout])
+      [connect_timeout: @timeout, recv_timeout: @timeout, timeout: @timeout])
   end
 
   defp required_scopes?(scopes) do

--- a/lib/rprel/github_release/http.ex
+++ b/lib/rprel/github_release/http.ex
@@ -57,8 +57,9 @@ defmodule Rprel.GithubRelease.HTTP do
   defp auth_header(token), do: %{"Authorization" => "token #{token}"}
 
   defp authenticated_post(url, body, token) do
+    timeout = Application.get_env(:rprel, :file_upload_timeout)
     HTTPoison.post!(url, body, auth_header(token),
-      [connect_timeout: 10_000, recv_timeout: 10_000, timeout: 10_000])
+      [connect_timeout: timeout, recv_timeout: timeout, timeout: timeout])
   end
 
   defp required_scopes?(scopes) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Rprel.Mixfile do
 
   def project do
     [app: :rprel,
-     version: "2.0.0",
+     version: "2.0.1",
      elixir: "~> 1.3.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
We tried adding `rprel release` to ag, but it failed because of a timeout while uploading the tarball. It seems like since we are upload files as big as (in this case) 350 MB, we should be giving it a lot more time. So I bumped it from 10,000 milliseconds (10 seconds) to 100,000 milliseconds (100 seconds).

I also placed that value in config so its easier to change in the future.