### PR TITLE
fix error where the unreadable error results in a crash

### DIFF
--- a/lib/rprel/messages.ex
+++ b/lib/rprel/messages.ex
@@ -8,6 +8,7 @@ defmodule Rprel.Messages do
   def invalid_branch, do: "You must provide a branch."
   def invalid_version, do: "You must provide a version number."
   def invalid_files, do: "You must provide at least one valid file."
+  def unreadable_files, do: "You must provide a file that is readable."
   def invalid_auth_token, do: "You must provide a valid GitHub authentication token."
   def release_already_exists, do: "A release for that version already exists. Please use a different version."
   def unspecified_error, do: "An unknown error has occurred."


### PR DESCRIPTION
Ran into an issue earlier today on buildkite where an unreadable file error occured, and instead of a clean error, we got a crash because the unreadable files function was never created.

Rectifying that here.