### PR TITLE
Use 1.4.0 application inference

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Rprel.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison, :porcelain]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
In Elixir 1.4.0 Mix automatically infers the applications that need to
be running. This updates to use that new syntax.